### PR TITLE
Feature tags on projects page

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -19,4 +19,20 @@ header:
 Samples of published and ongoing projects by CCOG. Sort them by computational or Earth Science tags. 
 
 Exciting new CCOG focus areas include sea level and large scale climate dynamics.
+
+{% case site.tag_archive.type %}
+  {% when "liquid" %}
+    {% assign path_type = "#" %}
+  {% when "jekyll-archives" %}
+    {% assign path_type = nil %}
+{% endcase %}
+
+<p class="page__taxonomy">
+  <span itemprop="keywords">
+  {% for tag in site.tags %}
+    <a href="{{  tag[0] | slugify | prepend: path_type | prepend: site.tag_archive.path | relative_url }}" class="page__taxonomy-item p-category" rel="tag">{{ tag[0] }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+  {% endfor %}
+  </span>
+</p>
+
 <!-- Coming soon! -->

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -16,8 +16,7 @@ header:
 
 # Projects
 
-Samples of published and ongoing projects by CCOG. Sort them by computational or Earth Science tags. 
-
+Samples of published and ongoing projects by CCOG. Sort them by computational or Earth Science tags.\
 Exciting new CCOG focus areas include sea level and large scale climate dynamics.
 
 {% case site.tag_archive.type %}


### PR DESCRIPTION
This adds the tags to the projects page and links to the sorted archive:
![image](https://github.com/CompClimate/ccog.github.io/assets/4548561/b0f2d6bd-aea5-4fe1-b0c0-13a23a44cc0c)

We can also put this on the bottom.
